### PR TITLE
feat: enable debug-embed on rust-embed for dev-mode builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -354,6 +354,7 @@ crate_index.spec(
 # Embedded UI assets
 crate_index.spec(
     features = [
+        "debug-embed",
         "interpolate-folder-path",
         "deterministic-timestamps",
         "include-exclude",

--- a/packages/workshop_ui/crate/Cargo.toml
+++ b/packages/workshop_ui/crate/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.2.0"
 edition = "2024"
 
 [dependencies]
-rust-embed = { version = "8", features = ["interpolate-folder-path", "deterministic-timestamps", "include-exclude"] }
+rust-embed = { version = "8", features = ["debug-embed", "interpolate-folder-path", "deterministic-timestamps", "include-exclude"] }


### PR DESCRIPTION
 Enables the `debug-embed` feature on `rust-embed` so the `embedded-ui` crate bakes the SvelteKit bundle into the binary in all build modes, not just release.

`rust-embed` defaults to reading files from disk at runtime in debug builds and only embeds in release. That means `cargo build -p workshop --features embedded-ui` and fastbuild Bazel images produce binaries whose UI assets point at compile-time paths that don't exist at runtime in the container. `debug-embed` forces embedding regardless of build mode.

  |                          | fastbuild                      | opt                             |
  |--------------------------|--------------------------------|---------------------------------|
  | without `debug-embed`    | image broken (UI 404)          | image works                     |
  | with `debug-embed` (this PR) | image works, unoptimized       | image works                     |

  ### Tradeoff

If you edit SvelteKit source while rebuilding an `embedded-ui` binary in fastbuild, `rust-embed` re-runs and `workshop_ui_crate` recompiles. The UI dev loop (`pnpm dev` + non-`embedded-ui` binary) isn't affected.
